### PR TITLE
Change target framework to reduce dependencies installed by Nuget

### DIFF
--- a/PlaylistsNET/PlaylistsNET.csproj
+++ b/PlaylistsNET/PlaylistsNET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;net45</TargetFrameworks>
     <Authors>Tomasz Walecki</Authors>
     <Company />
     <PackageProjectUrl>https://github.com/tmk907/PlaylistsNET</PackageProjectUrl>


### PR DESCRIPTION
When installing PlaylistsNet from Nuget for a .NET Framework application, Nuget asks to install 46 dependencies:

```
Microsoft.NETCore.Platforms
Microsoft.Win32.Primitives
NETStandard.Library
System.AppContext
System.Collections
System.Collections.Concurrent
System.Console
System.Diagnostics.Debug
System.Diagnostics.DiagnosticSource
System.Diagnostics.Tools
System.Diagnostics.Tracing
System.Globalization
System.Globalization.Calendars
System.IO
System.IO.Compression
System.IO.Compression.ZipFile
System.IO.FileSystem
System.IO.FileSystem.Primitives
System.Linq
System.Linq.Expressions
System.Net.Http
System.Net.Primitives
System.Net.Sockets
System.ObjectModel
System.Reflection
System.Reflection.Extensions
System.Reflection.Primitives
System.Resources.ResourceManager
System.Runtime
System.Runtime.Extensions
System.Runtime.Handles
System.Runtime.InteropServices
System.Runtime.InteropServices.RuntimeInformation
System.Runtime.Numerics
System.Security.Cryptography.Algorithms
System.Security.Cryptography.Encoding
System.Security.Cryptography.Primitives
System.Security.Cryptography.X509Certificates
System.Text.Encoding
System.Text.Encoding.Extensions
System.Text.RegularExpressions
System.Threading
System.Threading.Tasks
System.Threading.Timer
System.Xml.ReaderWriter
System.Xml.XDocument
```

By targeting multiple frameworks as proposed in this pull request, it will allow the Nuget client to reduce the dependencies installed. The proposed change is to target, in addition to `netstandard1.4`:

* `netstandard2.0` for .NET Framework 4.7+
* `net4.5 `for .NET 4.5+

NuGet will choose the `net45` binaries for a .NET Framework application, avoiding the unnecessary dependencies when installing PlaylistsNET.

More info can be found on this [blog post](http://blog.tdwright.co.uk/2017/11/21/update-getting-net-standard-apps-playing-nicely-on-nuget/).