### PR TITLE
fix bug where seconds string is formatted with a decimal

### DIFF
--- a/PlaylistsNET/Content/M3u8Content.cs
+++ b/PlaylistsNET/Content/M3u8Content.cs
@@ -116,7 +116,7 @@ namespace PlaylistsNET.Content
                 //0123456789
                 //#EXTINF:1234,
                 string s = line.Substring(8, line.IndexOf(',') - 8);
-                seconds = Int32.Parse(s);
+                seconds = (int)double.Parse(s);
             }
             catch { }
             return seconds;

--- a/PlaylistsNET/Content/M3uContent.cs
+++ b/PlaylistsNET/Content/M3uContent.cs
@@ -121,7 +121,7 @@ namespace PlaylistsNET.Content
                 //0123456789
                 //#EXTINF:1234,
                 string s = line.Substring(8, line.IndexOf(',') - 8);
-                seconds = Int32.Parse(s);
+                seconds = (int)double.Parse(s);
             }
             catch { }
             return seconds;


### PR DESCRIPTION
fixed a bug where the seconds string had a decimal in it  e.g.  "3.00000" 