### PR TITLE
Add ToText support for HLS playlists

### DIFF
--- a/PlaylistsNET.Tests/Examples/2seq.wpl
+++ b/PlaylistsNET.Tests/Examples/2seq.wpl
@@ -1,33 +1,33 @@
 <?wpl version="1.0"?>
 <smil>
-	<head>
-		<author />
-		<guid>{80034981-91E5-45A6-9895-5447D7463CDE}</guid>
-		<meta name="totalDuration" content="0" />
-		<meta name="ItemCount" content="46" />
-		<meta name="Generator" content="Entertainment Platform -- 3.6.2304.0" />
-		<title>Eurowizja do nagrania</title>
-		</head>
-	<body>
-		<seq>
-			<media src="D:\Tak to Było\22-05-2010\Allisons - Are You Sure.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Allisons - Are You Sure" trackArtist="Nieznany wykonawca" />
-			<media src="D:\Tak to Było\29-05-2010\ABBA - Waterloo.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="ABBA - Waterloo" trackArtist="Nieznany wykonawca" />
-		</seq>
-		<seq>
-			<smartPlaylist version="1.0.0.0">
-				<querySet>
-					<sourceFilter id="{4202947A-A563-4B05-A754-A1B4B5989849}" name="Muzyka w mojej bibliotece">
-						<fragment name="Last play date">
-							<argument name="condition">Is Before</argument>
-							<argument name="value">Last month</argument>
-						</fragment>
-					</sourceFilter>
-				</querySet>
-			</smartPlaylist>
-		</seq>
-		<seq>
-			<media src="D:\Tak to Było\29-05-2010\Bobbysocks - La Det Swinge.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Bobbysocks - La Det Swinge" trackArtist="Nieznany wykonawca" />
-			<media src="D:\Tak to Było\29-05-2010\Brotherhood of Man - Save Your Kisses For Me.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Brotherhood of Man - Save Your Kisses For Me" trackArtist="Nieznany wykonawca" />
-	  </seq>
-	</body>
+    <head>
+        <author />
+        <guid>{80034981-91E5-45A6-9895-5447D7463CDE}</guid>
+        <meta name="totalDuration" content="0" />
+        <meta name="ItemCount" content="46" />
+        <meta name="Generator" content="Entertainment Platform -- 3.6.2304.0" />
+        <title>Eurowizja do nagrania</title>
+        </head>
+    <body>
+        <seq>
+            <media src="D:\Tak to Było\22-05-2010\Allisons - Are You Sure.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Allisons - Are You Sure" trackArtist="Nieznany wykonawca" />
+            <media src="D:\Tak to Było\29-05-2010\ABBA - Waterloo.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="ABBA - Waterloo" trackArtist="Nieznany wykonawca" />
+        </seq>
+        <seq>
+            <smartPlaylist version="1.0.0.0">
+                <querySet>
+                    <sourceFilter id="{4202947A-A563-4B05-A754-A1B4B5989849}" name="Muzyka w mojej bibliotece">
+                        <fragment name="Last play date">
+                            <argument name="condition">Is Before</argument>
+                            <argument name="value">Last month</argument>
+                        </fragment>
+                    </sourceFilter>
+                </querySet>
+            </smartPlaylist>
+        </seq>
+        <seq>
+            <media src="D:\Tak to Było\29-05-2010\Bobbysocks - La Det Swinge.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Bobbysocks - La Det Swinge" trackArtist="Nieznany wykonawca" />
+            <media src="D:\Tak to Było\29-05-2010\Brotherhood of Man - Save Your Kisses For Me.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Brotherhood of Man - Save Your Kisses For Me" trackArtist="Nieznany wykonawca" />
+      </seq>
+    </body>
 </smil>

--- a/PlaylistsNET.Tests/Examples/2seqoutputTest.wpl
+++ b/PlaylistsNET.Tests/Examples/2seqoutputTest.wpl
@@ -1,32 +1,32 @@
 <?wpl version="1.0"?>
 <smil>
-	<head>
-		<author />
-		<guid>{80034981-91E5-45A6-9895-5447D7463CDE}</guid>
-		<meta name="totalDuration" content="0" />
-		<meta name="ItemCount" content="46" />
-		<meta name="Generator" content="Entertainment Platform -- 3.6.2304.0" />
-		<title>abc</title>
-	</head>
-	<body>
-		<seq>
-		  <media src="D:\abc.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="abc" trackArtist="Nieznany" />
-		</seq>
-		<seq>
-			<smartPlaylist version="1.0.0.0">
-				<querySet>
-					<sourceFilter id="{4202947A-A563-4B05-A754-A1B4B5989849}" name="Muzyka w mojej bibliotece">
-						<fragment name="Last play date">
-							<argument name="condition">Is Before</argument>
-							<argument name="value">Last month</argument>
-						</fragment>
-					</sourceFilter>
-				</querySet>
-			</smartPlaylist>
-		</seq>
-		<seq>
-			<media src="D:\Tak to Było\29-05-2010\Bobbysocks - La Det Swinge.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Bobbysocks - La Det Swinge" trackArtist="Nieznany wykonawca" />
-			<media src="D:\Tak to Było\29-05-2010\Brotherhood of Man - Save Your Kisses For Me.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Brotherhood of Man - Save Your Kisses For Me" trackArtist="Nieznany wykonawca" />
-		</seq>
-	</body>
+    <head>
+        <author />
+        <guid>{80034981-91E5-45A6-9895-5447D7463CDE}</guid>
+        <meta name="totalDuration" content="0" />
+        <meta name="ItemCount" content="46" />
+        <meta name="Generator" content="Entertainment Platform -- 3.6.2304.0" />
+        <title>abc</title>
+    </head>
+    <body>
+        <seq>
+          <media src="D:\abc.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="abc" trackArtist="Nieznany" />
+        </seq>
+        <seq>
+            <smartPlaylist version="1.0.0.0">
+                <querySet>
+                    <sourceFilter id="{4202947A-A563-4B05-A754-A1B4B5989849}" name="Muzyka w mojej bibliotece">
+                        <fragment name="Last play date">
+                            <argument name="condition">Is Before</argument>
+                            <argument name="value">Last month</argument>
+                        </fragment>
+                    </sourceFilter>
+                </querySet>
+            </smartPlaylist>
+        </seq>
+        <seq>
+            <media src="D:\Tak to Było\29-05-2010\Bobbysocks - La Det Swinge.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Bobbysocks - La Det Swinge" trackArtist="Nieznany wykonawca" />
+            <media src="D:\Tak to Było\29-05-2010\Brotherhood of Man - Save Your Kisses For Me.wav" albumTitle="Nieznany album" albumArtist="Nieznany wykonawca" trackTitle="Brotherhood of Man - Save Your Kisses For Me" trackArtist="Nieznany wykonawca" />
+        </seq>
+    </body>
 </smil>

--- a/PlaylistsNET.Tests/HlsTests.cs
+++ b/PlaylistsNET.Tests/HlsTests.cs
@@ -6,87 +6,87 @@ using System.IO;
 
 namespace PlaylistsNET.Tests
 {
-	[TestClass]
-	public class HlsTest
-	{
-		[TestMethod]
-		public void GetFromStream_ReadPlaylistHlsMediaAndCompareWithObject_Equal()
-		{
-			var content = new HlsMediaContent();
+    [TestClass]
+    public class HlsTest
+    {
+        [TestMethod]
+        public void GetFromStream_ReadPlaylistHlsMediaAndCompareWithObject_Equal()
+        {
+            var content = new HlsMediaContent();
 
-			using (var stream = Helpers.ReadStream("PlaylistExtHls.m3u"))
-			{
-				var file = content.GetFromStream(stream);
+            using (var stream = Helpers.ReadStream("PlaylistExtHls.m3u"))
+            {
+                var file = content.GetFromStream(stream);
 
-				Assert.AreEqual("NO", file.AllowCache, false);
-				Assert.AreEqual(1, file.Version);
-				Assert.AreEqual(10, file.TargetDuration);
-				Assert.AreEqual(56, file.PlaylistEntries.Count);
+                Assert.AreEqual("NO", file.AllowCache, false);
+                Assert.AreEqual(1, file.Version);
+                Assert.AreEqual(10, file.TargetDuration);
+                Assert.AreEqual(56, file.PlaylistEntries.Count);
 
-				var entry = file.PlaylistEntries[0];
-				Assert.AreEqual(@"METHOD=AES-128,URI=""key""", entry.Key);
-				Assert.AreEqual(10, entry.Duration);
-				Assert.AreEqual(147483, entry.MediaSequence);
-				Assert.AreEqual("stream1_256k_1_061532839410_00147483_v3.aac", entry.Path);
+                var entry = file.PlaylistEntries[0];
+                Assert.AreEqual(@"METHOD=AES-128,URI=""key""", entry.Key);
+                Assert.AreEqual(10, entry.Duration);
+                Assert.AreEqual(147483, entry.MediaSequence);
+                Assert.AreEqual("stream1_256k_1_061532839410_00147483_v3.aac", entry.Path);
 
-				entry = file.PlaylistEntries[1];
-				Assert.AreEqual(@"METHOD=AES-128,URI=""key""", entry.Key);
-				Assert.AreEqual(10, entry.Duration);
-				Assert.AreEqual(147484, entry.MediaSequence);
-				Assert.AreEqual("stream1_256k_1_061532849162_00147484_v3.aac", entry.Path);
-			}
-		}
+                entry = file.PlaylistEntries[1];
+                Assert.AreEqual(@"METHOD=AES-128,URI=""key""", entry.Key);
+                Assert.AreEqual(10, entry.Duration);
+                Assert.AreEqual(147484, entry.MediaSequence);
+                Assert.AreEqual("stream1_256k_1_061532849162_00147484_v3.aac", entry.Path);
+            }
+        }
 
-		[TestMethod]
-		public void GetFromStream_ReadPlaylistHlsMasterAndCompareWithObject_Equal()
-		{
-			var content = new HlsMasterContent();
+        [TestMethod]
+        public void GetFromStream_ReadPlaylistHlsMasterAndCompareWithObject_Equal()
+        {
+            var content = new HlsMasterContent();
 
-			using (var stream = Helpers.ReadStream("PlaylistExtHlsMaster.m3u"))
-			{
-				var file = content.GetFromStream(stream);
+            using (var stream = Helpers.ReadStream("PlaylistExtHlsMaster.m3u"))
+            {
+                var file = content.GetFromStream(stream);
 
-				Assert.AreEqual("NO", file.AllowCache, false);
-				Assert.AreEqual(1, file.Version);
-				Assert.AreEqual(4, file.PlaylistEntries.Count);
+                Assert.AreEqual("NO", file.AllowCache, false);
+                Assert.AreEqual(1, file.Version);
+                Assert.AreEqual(4, file.PlaylistEntries.Count);
 
-				var entry = file.PlaylistEntries[0];
-				Assert.AreEqual(1, entry.ProgramId);
-				Assert.AreEqual(281600, entry.Bandwidth);
-				Assert.AreEqual("mp4a.40.2", entry.Codecs[0]);
-				Assert.AreEqual("HLS_9506_256k_v3/9506_256k_large_v3.m3u8", entry.Path);
-			}
-		}
+                var entry = file.PlaylistEntries[0];
+                Assert.AreEqual(1, entry.ProgramId);
+                Assert.AreEqual(281600, entry.Bandwidth);
+                Assert.AreEqual("mp4a.40.2", entry.Codecs[0]);
+                Assert.AreEqual("HLS_9506_256k_v3/9506_256k_large_v3.m3u8", entry.Path);
+            }
+        }
 
-		[TestMethod]
-		public void Throw_exception_when_create_hls_from_non_hls()
-		{
-			var content = new HlsMasterContent();
+        [TestMethod]
+        public void Throw_exception_when_create_hls_from_non_hls()
+        {
+            var content = new HlsMasterContent();
 
-			var playlistString = "this is not a playlist";
-			Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
+            var playlistString = "this is not a playlist";
+            Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
 
-			playlistString = "#EXTM3U";
-			Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
-		}
+            playlistString = "#EXTM3U";
+            Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
+        }
 
-		[TestMethod]
-		public void Throw_exception_when_create_master_from_media()
-		{
-			var content = new HlsMasterContent();
+        [TestMethod]
+        public void Throw_exception_when_create_master_from_media()
+        {
+            var content = new HlsMasterContent();
 
-			var playlistString = "#EXTM3U\r\n#EXT-X-VERSION:1\r\n#EXTINF:-1,";
-			Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
-		}
+            var playlistString = "#EXTM3U\r\n#EXT-X-VERSION:1\r\n#EXTINF:-1,";
+            Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
+        }
 
-		[TestMethod]
-		public void Throw_exception_when_create_media_from_master()
-		{
-			var content = new HlsMediaContent();
+        [TestMethod]
+        public void Throw_exception_when_create_media_from_master()
+        {
+            var content = new HlsMediaContent();
 
-			var playlistString = "#EXTM3U\r\n#EXT-X-VERSION:1\r\n#EXT-X-STREAM-INF:BANDWIDTH=124000";
-			Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
-		}
+            var playlistString = "#EXTM3U\r\n#EXT-X-VERSION:1\r\n#EXT-X-STREAM-INF:BANDWIDTH=124000";
+            Assert.ThrowsException<FormatException>(() => content.GetFromString(playlistString));
+        }
 
         [TestMethod]
         public void Round_trip_master_parse_totext()
@@ -119,25 +119,25 @@ namespace PlaylistsNET.Tests
             }
         }
 
-		[TestMethod]
-		public void Round_trip_media_parse_totext()
-		{
+        [TestMethod]
+        public void Round_trip_media_parse_totext()
+        {
             var content = new HlsMediaContent();
 
             using (var stream = Helpers.ReadStream("PlaylistExtHls.m3u"))
             {
-				string contents;
-				using (StreamReader sr = new StreamReader(stream))
-				{
-					contents = sr.ReadToEnd();
-				}
+                string contents;
+                using (StreamReader sr = new StreamReader(stream))
+                {
+                    contents = sr.ReadToEnd();
+                }
 
-				var playlist = content.GetFromString(contents);
+                var playlist = content.GetFromString(contents);
 
-				var toText = content.ToText(playlist);
+                var toText = content.ToText(playlist);
 
-				content = new HlsMediaContent();
-				var file = content.GetFromString(toText);
+                content = new HlsMediaContent();
+                var file = content.GetFromString(toText);
 
                 Assert.AreEqual("NO", file.AllowCache, false);
                 Assert.AreEqual(1, file.Version);
@@ -157,5 +157,5 @@ namespace PlaylistsNET.Tests
                 Assert.AreEqual("stream1_256k_1_061532849162_00147484_v3.aac", entry.Path);
             }
         }
-	}
+    }
 }

--- a/PlaylistsNET.Tests/M3uTest.cs
+++ b/PlaylistsNET.Tests/M3uTest.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace PlaylistsNET.Tests
 {
-	[TestClass]
+    [TestClass]
     public class M3uTest
     {
         [TestMethod]
@@ -112,24 +112,24 @@ namespace PlaylistsNET.Tests
                 Title = "E Chiove",
             });
 
-			using (var stream = Helpers.ReadStream("PlaylistNotExt.m3u"))
-			{
-				var file = content.GetFromStream(stream);
+            using (var stream = Helpers.ReadStream("PlaylistNotExt.m3u"))
+            {
+                var file = content.GetFromStream(stream);
 
-				Assert.AreEqual(playlist.IsExtended, file.IsExtended);
-				Assert.AreEqual(playlist.PlaylistEntries.Count, file.PlaylistEntries.Count);
+                Assert.AreEqual(playlist.IsExtended, file.IsExtended);
+                Assert.AreEqual(playlist.PlaylistEntries.Count, file.PlaylistEntries.Count);
 
-				Assert.AreEqual(playlist.PlaylistEntries[0].Path, file.PlaylistEntries[0].Path);
-				Assert.AreEqual(playlist.PlaylistEntries[0].Title, file.PlaylistEntries[0].Title);
+                Assert.AreEqual(playlist.PlaylistEntries[0].Path, file.PlaylistEntries[0].Path);
+                Assert.AreEqual(playlist.PlaylistEntries[0].Title, file.PlaylistEntries[0].Title);
 
-				Assert.AreEqual(playlist.PlaylistEntries[1].Path, file.PlaylistEntries[1].Path);
-				Assert.AreNotEqual(playlist.PlaylistEntries[1].Title, file.PlaylistEntries[1].Title);
+                Assert.AreEqual(playlist.PlaylistEntries[1].Path, file.PlaylistEntries[1].Path);
+                Assert.AreNotEqual(playlist.PlaylistEntries[1].Title, file.PlaylistEntries[1].Title);
                 Assert.IsNull(playlist.PlaylistEntries[1].Title);
                 Assert.AreEqual("", file.PlaylistEntries[1].Title);
 
                 Assert.AreEqual(playlist.PlaylistEntries[2].Path, file.PlaylistEntries[2].Path);
-				Assert.AreNotEqual(playlist.PlaylistEntries[2].Title, file.PlaylistEntries[2].Title);
-			}
+                Assert.AreNotEqual(playlist.PlaylistEntries[2].Title, file.PlaylistEntries[2].Title);
+            }
         }
 
         [TestMethod]
@@ -165,31 +165,31 @@ namespace PlaylistsNET.Tests
                 Title = "Andrea Bocelli - E Chiove",
             });
 
-			using (var stream = Helpers.ReadStream("PlaylistExt.m3u"))
-			{
-				var file = content.GetFromStream(stream);
+            using (var stream = Helpers.ReadStream("PlaylistExt.m3u"))
+            {
+                var file = content.GetFromStream(stream);
 
-				Assert.AreEqual(playlist.IsExtended, file.IsExtended);
-				Assert.AreEqual(playlist.PlaylistEntries.Count, file.PlaylistEntries.Count);
+                Assert.AreEqual(playlist.IsExtended, file.IsExtended);
+                Assert.AreEqual(playlist.PlaylistEntries.Count, file.PlaylistEntries.Count);
 
-				Assert.AreEqual(playlist.PlaylistEntries[0].Path, file.PlaylistEntries[0].Path);
-				Assert.AreEqual(playlist.PlaylistEntries[0].Title, file.PlaylistEntries[0].Title);
+                Assert.AreEqual(playlist.PlaylistEntries[0].Path, file.PlaylistEntries[0].Path);
+                Assert.AreEqual(playlist.PlaylistEntries[0].Title, file.PlaylistEntries[0].Title);
                 Assert.AreEqual(playlist.PlaylistEntries[0].Album, file.PlaylistEntries[0].Album);
                 Assert.AreEqual(playlist.PlaylistEntries[0].AlbumArtist, file.PlaylistEntries[0].AlbumArtist);
 
                 Assert.AreEqual(playlist.PlaylistEntries[1].Path, file.PlaylistEntries[1].Path);
-				Assert.AreEqual(playlist.PlaylistEntries[1].Title, file.PlaylistEntries[1].Title);
+                Assert.AreEqual(playlist.PlaylistEntries[1].Title, file.PlaylistEntries[1].Title);
                 Assert.AreNotEqual(playlist.PlaylistEntries[1].Album, file.PlaylistEntries[1].Album);
                 Assert.AreNotEqual(playlist.PlaylistEntries[1].AlbumArtist, file.PlaylistEntries[1].AlbumArtist);
                 Assert.IsNull(playlist.PlaylistEntries[1].Album);
                 Assert.AreEqual("", file.PlaylistEntries[1].Album);
 
                 Assert.AreEqual(playlist.PlaylistEntries[1].CustomProperties.Count(), file.PlaylistEntries[1].CustomProperties.Count());
-				Assert.AreEqual(playlist.PlaylistEntries[1].CustomProperties.Last().Key, file.PlaylistEntries[1].CustomProperties.Last().Key);
-				Assert.AreEqual(playlist.PlaylistEntries[1].CustomProperties.Last().Value, file.PlaylistEntries[1].CustomProperties.Last().Value);
+                Assert.AreEqual(playlist.PlaylistEntries[1].CustomProperties.Last().Key, file.PlaylistEntries[1].CustomProperties.Last().Key);
+                Assert.AreEqual(playlist.PlaylistEntries[1].CustomProperties.Last().Value, file.PlaylistEntries[1].CustomProperties.Last().Value);
 
-				Assert.AreEqual(playlist.PlaylistEntries[2].Path, file.PlaylistEntries[2].Path);
-				Assert.AreEqual(playlist.PlaylistEntries[2].Title, file.PlaylistEntries[2].Title);
+                Assert.AreEqual(playlist.PlaylistEntries[2].Path, file.PlaylistEntries[2].Path);
+                Assert.AreEqual(playlist.PlaylistEntries[2].Title, file.PlaylistEntries[2].Title);
                 Assert.AreEqual(playlist.PlaylistEntries[2].Album, file.PlaylistEntries[2].Album);
                 Assert.AreEqual(playlist.PlaylistEntries[2].AlbumArtist, file.PlaylistEntries[2].AlbumArtist);
             }
@@ -217,5 +217,5 @@ namespace PlaylistsNET.Tests
                 Assert.AreEqual(entry.Title, fileEntry.Title);
             }
         }
-	}
+    }
 }

--- a/PlaylistsNET/Content/HlsContent.cs
+++ b/PlaylistsNET/Content/HlsContent.cs
@@ -8,54 +8,11 @@ using System.Text.RegularExpressions;
 
 namespace PlaylistsNET.Content
 {
-	public class HlsMediaWriter
-	{
-        protected void AppendGeneralHeaders<T, U>(T playlist, ref StringBuilder sb)
-			where T : HlsPlaylist<U>
-			where U : HlsPlaylistEntry
-        {
-            // HLS requires this line as the first line of playlist
-            sb.AppendLine("#EXTM3U");
-            // VERSION always required
-            sb.AppendLine($"#EXT-X-VERSION:{playlist.Version}");
-
-            CheckNullAndAppend("#EXT-X-ALLOW-CACHE", playlist.AllowCache, sb);
-
-            foreach (var currentComment in playlist.Comments)
-            {
-                sb.AppendLine($"#{currentComment}");
-            }
-        }
-        protected void CheckAndAppend<T>(string tag,
-			T element,
-			StringBuilder sb,
-			Func<T, bool> validator)
-        {
-            if (validator(element) == true)
-            {
-                sb.AppendLine($"{tag}:{element}");
-            }
-        }
-
-        protected void CheckNullAndAppend<T>(string tag,
-            T element,
-            StringBuilder sb)
-        {
-            CheckAndAppend(tag, element, sb, e => e != null);
-        }
-
-        protected void CheckEmptyStringAndAppend(string tag,
-            string element,
-            StringBuilder sb)
-        {
-            CheckAndAppend(tag, element, sb, e => !String.IsNullOrEmpty(e));
-        }
-    }
-	public class HlsMediaContent : HlsMediaWriter,
-		IPlaylistParser<HlsMediaPlaylist>,
-		IPlaylistWriter<HlsMediaPlaylist>
+    public class HlsMediaContent : HlsMediaWriter,
+        IPlaylistParser<HlsMediaPlaylist>,
+        IPlaylistWriter<HlsMediaPlaylist>
     {
-		        public string ToText(HlsMediaPlaylist playlist)
+        public string ToText(HlsMediaPlaylist playlist)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -100,187 +57,187 @@ namespace PlaylistsNET.Content
             return sb.ToString();
         }
         public HlsMediaPlaylist GetFromStream(Stream stream)
-		{
-			StreamReader streamReader = new StreamReader(stream);
-			return GetFromString(streamReader.ReadToEnd());
-		}
+        {
+            StreamReader streamReader = new StreamReader(stream);
+            return GetFromString(streamReader.ReadToEnd());
+        }
 
-		public HlsMediaPlaylist GetFromString(string playlistString)
-		{
-			var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
+        public HlsMediaPlaylist GetFromString(string playlistString)
+        {
+            var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
 
-			// Not an EXT playlist, so can't be an HLS playlist
-			if (playlistLines[0] != "#EXTM3U")
-			{
-				throw new FormatException("Playlist missing required EXTM3U tag.");
-			}
+            // Not an EXT playlist, so can't be an HLS playlist
+            if (playlistLines[0] != "#EXTM3U")
+            {
+                throw new FormatException("Playlist missing required EXTM3U tag.");
+            }
 
-			// Remove "#EXTM3U" as it is no longer needed
-			playlistLines.RemoveAt(0);
+            // Remove "#EXTM3U" as it is no longer needed
+            playlistLines.RemoveAt(0);
 
-			// EXT playlist, but not HLS playlist, parse with the EXT parser
-			var isHls = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-VERSION:\d$")).Any();
-			if (!isHls)
-			{
-				throw new FormatException("Playlist missing required EXT-X-VERSION tag.");
-			}
+            // EXT playlist, but not HLS playlist, parse with the EXT parser
+            var isHls = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-VERSION:\d$")).Any();
+            if (!isHls)
+            {
+                throw new FormatException("Playlist missing required EXT-X-VERSION tag.");
+            }
 
-			// HLS Master, not Media
-			var isMaster = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-STREAM-INF:.+$")).Any();
-			isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-MEDIA:(.*)$")).Any();
-			isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-I-FRAME-STREAM-INF:(.*)$")).Any();
-			isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-SESSION-DATA:(.*)$")).Any();
-			isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-SESSION-KEY:(.*)$")).Any();
-			if (isMaster)
-			{
-				throw new FormatException("Playlist appears to be a HLS Master playlist.");
-			}
+            // HLS Master, not Media
+            var isMaster = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-STREAM-INF:.+$")).Any();
+            isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-MEDIA:(.*)$")).Any();
+            isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-I-FRAME-STREAM-INF:(.*)$")).Any();
+            isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-SESSION-DATA:(.*)$")).Any();
+            isMaster = isMaster || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-SESSION-KEY:(.*)$")).Any();
+            if (isMaster)
+            {
+                throw new FormatException("Playlist appears to be a HLS Master playlist.");
+            }
 
-			return GetMediaHls(playlistLines);
-		}
+            return GetMediaHls(playlistLines);
+        }
 
-		private HlsMediaPlaylist GetMediaHls(List<string> playlistLines)
-		{
-			var playlist = new HlsMediaPlaylist();
-			var currentEntry = new HlsMediaPlaylistEntry();
-			foreach (var currentLine in playlistLines)
-			{
-				// Media and Master tags
-				var hlsMatch = Regex.Match(currentLine, @"^#EXT-X-VERSION:(\d*)$");
-				if (hlsMatch.Success)
-				{
-					playlist.Version = int.Parse(hlsMatch.Groups[1].Value);
-					continue;
-				}
+        private HlsMediaPlaylist GetMediaHls(List<string> playlistLines)
+        {
+            var playlist = new HlsMediaPlaylist();
+            var currentEntry = new HlsMediaPlaylistEntry();
+            foreach (var currentLine in playlistLines)
+            {
+                // Media and Master tags
+                var hlsMatch = Regex.Match(currentLine, @"^#EXT-X-VERSION:(\d*)$");
+                if (hlsMatch.Success)
+                {
+                    playlist.Version = int.Parse(hlsMatch.Groups[1].Value);
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-ALLOW-CACHE:(.*)$");
-				if (hlsMatch.Success)
-				{
-					playlist.AllowCache = hlsMatch.Groups[1].Value;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-ALLOW-CACHE:(.*)$");
+                if (hlsMatch.Success)
+                {
+                    playlist.AllowCache = hlsMatch.Groups[1].Value;
+                    continue;
+                }
 
-				// Media playlist tags only
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-TARGETDURATION:(\d*)$");
-				if (hlsMatch.Success)
-				{
-					playlist.TargetDuration = int.Parse(hlsMatch.Groups[1].Value);
-					continue;
-				}
+                // Media playlist tags only
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-TARGETDURATION:(\d*)$");
+                if (hlsMatch.Success)
+                {
+                    playlist.TargetDuration = int.Parse(hlsMatch.Groups[1].Value);
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-MEDIA-SEQUENCE:(\d*)$");
-				if (hlsMatch.Success)
-				{
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-MEDIA-SEQUENCE:(\d*)$");
+                if (hlsMatch.Success)
+                {
                     var mediaSequence = long.Parse(hlsMatch.Groups[1].Value);
                     playlist.MediaSequence = mediaSequence;
                     currentEntry.MediaSequence = mediaSequence;
-					continue;
-				}
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-DISCONTINUITY-SEQUENCE:(\d*)$");
-				if (hlsMatch.Success)
-				{
-					playlist.DiscontinuitySequence = long.Parse(hlsMatch.Groups[1].Value);
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-DISCONTINUITY-SEQUENCE:(\d*)$");
+                if (hlsMatch.Success)
+                {
+                    playlist.DiscontinuitySequence = long.Parse(hlsMatch.Groups[1].Value);
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^EXT-X-PLAYLIST-TYPE:(.*)$");
-				if (hlsMatch.Success)
-				{
-					playlist.PlaylistType = hlsMatch.Groups[1].Value;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^EXT-X-PLAYLIST-TYPE:(.*)$");
+                if (hlsMatch.Success)
+                {
+                    playlist.PlaylistType = hlsMatch.Groups[1].Value;
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-ENDLIST$");
-				if (hlsMatch.Success)
-				{
-					playlist.EndList = true;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-ENDLIST$");
+                if (hlsMatch.Success)
+                {
+                    playlist.EndList = true;
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-I-FRAMES-ONLY$");
-				if (hlsMatch.Success)
-				{
-					playlist.IFramesOnly = true;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-I-FRAMES-ONLY$");
+                if (hlsMatch.Success)
+                {
+                    playlist.IFramesOnly = true;
+                    continue;
+                }
 
-				// Per entry tags
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-KEY:(.*)$");
-				if (hlsMatch.Success)
-				{
-					currentEntry.Key = hlsMatch.Groups[1].Value;
-					continue;
-				}
+                // Per entry tags
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-KEY:(.*)$");
+                if (hlsMatch.Success)
+                {
+                    currentEntry.Key = hlsMatch.Groups[1].Value;
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-MAP:(.*)$");
-				if (hlsMatch.Success)
-				{
-					currentEntry.Map = hlsMatch.Groups[1].Value;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-MAP:(.*)$");
+                if (hlsMatch.Success)
+                {
+                    currentEntry.Map = hlsMatch.Groups[1].Value;
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-BYTERANGE:(.*)$");
-				if (hlsMatch.Success)
-				{
-					currentEntry.ByteRange = hlsMatch.Groups[1].Value;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-BYTERANGE:(.*)$");
+                if (hlsMatch.Success)
+                {
+                    currentEntry.ByteRange = hlsMatch.Groups[1].Value;
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#EXT-X-PROGRAM-DATE-TIME:(.*)$");
-				if (hlsMatch.Success)
-				{
-					currentEntry.ProgramDateTime = DateTime.Parse(hlsMatch.Groups[1].Value).ToUniversalTime();
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#EXT-X-PROGRAM-DATE-TIME:(.*)$");
+                if (hlsMatch.Success)
+                {
+                    currentEntry.ProgramDateTime = DateTime.Parse(hlsMatch.Groups[1].Value).ToUniversalTime();
+                    continue;
+                }
 
-				hlsMatch = Regex.Match(currentLine, @"^#(EXT-X-DISCONTINUITY)$");
-				if (hlsMatch.Success)
-				{
-					currentEntry.Discontinuity = true;
-					continue;
-				}
+                hlsMatch = Regex.Match(currentLine, @"^#(EXT-X-DISCONTINUITY)$");
+                if (hlsMatch.Success)
+                {
+                    currentEntry.Discontinuity = true;
+                    continue;
+                }
 
-				var match = Regex.Match(currentLine, @"^#EXTINF:(-?\d*),(.*)$");
-				if (match.Success)
-				{
-					currentEntry.Duration = string.IsNullOrEmpty(match.Groups[1].Value) ? 0 : int.Parse(match.Groups[1].Value);
-					currentEntry.Title = match.Groups[2].Value;
-					continue;
-				}
+                var match = Regex.Match(currentLine, @"^#EXTINF:(-?\d*),(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.Duration = string.IsNullOrEmpty(match.Groups[1].Value) ? 0 : int.Parse(match.Groups[1].Value);
+                    currentEntry.Title = match.Groups[2].Value;
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(EXT.*):(.*)$");
-				if (match.Success)
-				{
-					currentEntry.CustomProperties.Add(match.Groups[1].Value, match.Groups[2].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(EXT.*):(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.CustomProperties.Add(match.Groups[1].Value, match.Groups[2].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(?!EXT)(.*)$");
-				if (match.Success)
-				{
-					currentEntry.Comments.Add(match.Groups[1].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(?!EXT)(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.Comments.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				currentEntry.Path = currentLine;
-				playlist.PlaylistEntries.Add(currentEntry);
+                currentEntry.Path = currentLine;
+                playlist.PlaylistEntries.Add(currentEntry);
 
-				// Key and Map apply to all subsequent entries until another Key or Map tag is specified
-				currentEntry = new HlsMediaPlaylistEntry()
-				{
-					MediaSequence = currentEntry.MediaSequence + 1,
-					Key = currentEntry.Key,
-					Map = currentEntry.Map
-				};
-			}
+                // Key and Map apply to all subsequent entries until another Key or Map tag is specified
+                currentEntry = new HlsMediaPlaylistEntry()
+                {
+                    MediaSequence = currentEntry.MediaSequence + 1,
+                    Key = currentEntry.Key,
+                    Map = currentEntry.Map
+                };
+            }
 
-			return playlist;
-		}
-	}
+            return playlist;
+        }
+    }
 
-	public class HlsMasterContent : HlsMediaWriter,
-		IPlaylistParser<HlsMasterPlaylist>,
+    public class HlsMasterContent : HlsMediaWriter,
+        IPlaylistParser<HlsMasterPlaylist>,
         IPlaylistWriter<HlsMasterPlaylist>
     {
         public string ToText(HlsMasterPlaylist playlist)
@@ -319,170 +276,213 @@ namespace PlaylistsNET.Content
             return sb.ToString();
         }
         public HlsMasterPlaylist GetFromStream(Stream stream)
-		{
-			StreamReader streamReader = new StreamReader(stream);
-			return GetFromString(streamReader.ReadToEnd());
-		}
+        {
+            StreamReader streamReader = new StreamReader(stream);
+            return GetFromString(streamReader.ReadToEnd());
+        }
 
-		public HlsMasterPlaylist GetFromString(string playlistString)
-		{
-			var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
+        public HlsMasterPlaylist GetFromString(string playlistString)
+        {
+            var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
 
-			// Not an EXT playlist, so can't be an HLS playlist
-			if (playlistLines[0] != "#EXTM3U")
-			{
-				throw new FormatException("Playlist missing required EXTM3U tag.");
-			}
+            // Not an EXT playlist, so can't be an HLS playlist
+            if (playlistLines[0] != "#EXTM3U")
+            {
+                throw new FormatException("Playlist missing required EXTM3U tag.");
+            }
 
-			// Remove "#EXTM3U" as it is no longer needed
-			playlistLines.RemoveAt(0);
+            // Remove "#EXTM3U" as it is no longer needed
+            playlistLines.RemoveAt(0);
 
-			// EXT playlist, but not HLS playlist, parse with the EXT parser
-			var isHls = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-VERSION:\d$")).Any();
-			if (!isHls)
-			{
-				throw new FormatException("Playlist missing required EXT-X-VERSION tag.");
-			}
+            // EXT playlist, but not HLS playlist, parse with the EXT parser
+            var isHls = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-VERSION:\d$")).Any();
+            if (!isHls)
+            {
+                throw new FormatException("Playlist missing required EXT-X-VERSION tag.");
+            }
 
-			// HLS Media playlist, not Master
-			var isMedia = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXTINF:.+$")).Any();
-			isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-TARGETDURATION:(\d*)$")).Any();
-			isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-MEDIA-SEQUENCE:(\d*)$")).Any();
-			isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-DISCONTINUITY-SEQUENCE:(\d*)$")).Any();
-			isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-PLAYLIST-TYPE:(.*)$")).Any();
-			isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-ENDLIST$")).Any();
-			isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-I-FRAMES-ONLY$")).Any();
-			if (isMedia)
-			{
-				throw new FormatException("Playlist appears to be a HLS Media playlist.");
-			}
+            // HLS Media playlist, not Master
+            var isMedia = playlistLines.Where(x => Regex.IsMatch(x, @"^#EXTINF:.+$")).Any();
+            isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-TARGETDURATION:(\d*)$")).Any();
+            isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-MEDIA-SEQUENCE:(\d*)$")).Any();
+            isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-DISCONTINUITY-SEQUENCE:(\d*)$")).Any();
+            isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-PLAYLIST-TYPE:(.*)$")).Any();
+            isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-ENDLIST$")).Any();
+            isMedia = isMedia || playlistLines.Where(x => Regex.IsMatch(x, @"^#EXT-X-I-FRAMES-ONLY$")).Any();
+            if (isMedia)
+            {
+                throw new FormatException("Playlist appears to be a HLS Media playlist.");
+            }
 
-			return GetMasterHls(playlistLines);
-		}
+            return GetMasterHls(playlistLines);
+        }
 
-		private HlsMasterPlaylist GetMasterHls(List<string> playlistLines)
-		{
-			var playlist = new HlsMasterPlaylist();
-			var currentEntry = new HlsMasterPlaylistEntry();
-			foreach (var currentLine in playlistLines)
-			{
-				// Media and Master tags
-				var match = Regex.Match(currentLine, @"^#EXT-X-VERSION:(\d*)$");
-				if (match.Success)
-				{
-					playlist.Version = int.Parse(match.Groups[1].Value);
-					continue;
-				}
+        private HlsMasterPlaylist GetMasterHls(List<string> playlistLines)
+        {
+            var playlist = new HlsMasterPlaylist();
+            var currentEntry = new HlsMasterPlaylistEntry();
+            foreach (var currentLine in playlistLines)
+            {
+                // Media and Master tags
+                var match = Regex.Match(currentLine, @"^#EXT-X-VERSION:(\d*)$");
+                if (match.Success)
+                {
+                    playlist.Version = int.Parse(match.Groups[1].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#EXT-X-ALLOW-CACHE:(.*)$");
-				if (match.Success)
-				{
-					playlist.AllowCache = match.Groups[1].Value;
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#EXT-X-ALLOW-CACHE:(.*)$");
+                if (match.Success)
+                {
+                    playlist.AllowCache = match.Groups[1].Value;
+                    continue;
+                }
 
-				// Master playlist-wide tags
-				match = Regex.Match(currentLine, @"^#EXT-X-MEDIA:(.*)$");
-				if (match.Success)
-				{
-					playlist.Media.Add(match.Groups[1].Value);
-					continue;
-				}
+                // Master playlist-wide tags
+                match = Regex.Match(currentLine, @"^#EXT-X-MEDIA:(.*)$");
+                if (match.Success)
+                {
+                    playlist.Media.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#EXT-X-I-FRAME-STREAM-INF:(.*)$");
-				if (match.Success)
-				{
-					playlist.IFrameStreamInf.Add(match.Groups[1].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#EXT-X-I-FRAME-STREAM-INF:(.*)$");
+                if (match.Success)
+                {
+                    playlist.IFrameStreamInf.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#EXT-X-SESSION-DATA:(.*)$");
-				if (match.Success)
-				{
-					playlist.SessionData.Add(match.Groups[1].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#EXT-X-SESSION-DATA:(.*)$");
+                if (match.Success)
+                {
+                    playlist.SessionData.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#EXT-X-SESSION-KEY:(.*)$");
-				if (match.Success)
-				{
-					playlist.SessionKey.Add(match.Groups[1].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#EXT-X-SESSION-KEY:(.*)$");
+                if (match.Success)
+                {
+                    playlist.SessionKey.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				// Master playlist entry tags
-				match = Regex.Match(currentLine, @"^#EXT-X-STREAM-INF:(.*)$");
-				if (match.Success)
-				{
-					var streamMatches = Regex.Matches(match.Groups[1].Value, @"([-A-Z]+)=(""[^""]+|[^,]+)");
+                // Master playlist entry tags
+                match = Regex.Match(currentLine, @"^#EXT-X-STREAM-INF:(.*)$");
+                if (match.Success)
+                {
+                    var streamMatches = Regex.Matches(match.Groups[1].Value, @"([-A-Z]+)=(""[^""]+|[^,]+)");
 
-					foreach (Match currentMatch in streamMatches)
-					{
-						var value = currentMatch.Groups[2].Value.Trim('"');
+                    foreach (Match currentMatch in streamMatches)
+                    {
+                        var value = currentMatch.Groups[2].Value.Trim('"');
 
-						switch (currentMatch.Groups[1].Value)
-						{
-							case "PROGRAM-ID":
-								currentEntry.ProgramId = int.Parse(value);
-								break;
-							case "BANDWIDTH":
-								currentEntry.Bandwidth = int.Parse(value);
-								break;
-							case "AVERAGE-BANDWIDTH":
-								currentEntry.AverageBandwidth = int.Parse(value);
-								break;
-							case "CODECS":
-								currentEntry.Codecs.AddRange(value.Split(','));
-								break;
-							case "RESOLUTION":
-								currentEntry.Resolution = value;
-								break;
-							case "FRAME-RATE":
-								currentEntry.FrameRate = double.Parse(value);
-								break;
-							case "HDCP-LEVEL":
-								currentEntry.HdcpLevel = value;
-								break;
-							case "AUDIO":
-								currentEntry.Audio = value;
-								break;
-							case "VIDEO":
-								currentEntry.Video = value;
-								break;
-							case "SUBTITLES":
-								currentEntry.Subtitles = value;
-								break;
-							case "CLOSED-CAPTIONS":
-								currentEntry.ClosedCaptions = value;
-								break;
-							default:
-								throw new FormatException($"STREAM-INF tag contains unknown attribute: {currentMatch.Groups[1].Value}");
-						}
-					}
+                        switch (currentMatch.Groups[1].Value)
+                        {
+                            case "PROGRAM-ID":
+                                currentEntry.ProgramId = int.Parse(value);
+                                break;
+                            case "BANDWIDTH":
+                                currentEntry.Bandwidth = int.Parse(value);
+                                break;
+                            case "AVERAGE-BANDWIDTH":
+                                currentEntry.AverageBandwidth = int.Parse(value);
+                                break;
+                            case "CODECS":
+                                currentEntry.Codecs.AddRange(value.Split(','));
+                                break;
+                            case "RESOLUTION":
+                                currentEntry.Resolution = value;
+                                break;
+                            case "FRAME-RATE":
+                                currentEntry.FrameRate = double.Parse(value);
+                                break;
+                            case "HDCP-LEVEL":
+                                currentEntry.HdcpLevel = value;
+                                break;
+                            case "AUDIO":
+                                currentEntry.Audio = value;
+                                break;
+                            case "VIDEO":
+                                currentEntry.Video = value;
+                                break;
+                            case "SUBTITLES":
+                                currentEntry.Subtitles = value;
+                                break;
+                            case "CLOSED-CAPTIONS":
+                                currentEntry.ClosedCaptions = value;
+                                break;
+                            default:
+                                throw new FormatException($"STREAM-INF tag contains unknown attribute: {currentMatch.Groups[1].Value}");
+                        }
+                    }
 
-					continue;
-				}
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(EXT.*):(.*)$");
-				if (match.Success)
-				{
-					currentEntry.CustomProperties.Add(match.Groups[1].Value, match.Groups[2].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(EXT.*):(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.CustomProperties.Add(match.Groups[1].Value, match.Groups[2].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(?!EXT)(.*)$");
-				if (match.Success)
-				{
-					currentEntry.Comments.Add(match.Groups[1].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(?!EXT)(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.Comments.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				currentEntry.Path = currentLine;
-				playlist.PlaylistEntries.Add(currentEntry);
-				currentEntry = new HlsMasterPlaylistEntry();
-			}
+                currentEntry.Path = currentLine;
+                playlist.PlaylistEntries.Add(currentEntry);
+                currentEntry = new HlsMasterPlaylistEntry();
+            }
 
-			return playlist;
-		}
-	}
+            return playlist;
+        }
+    }
+    public class HlsMediaWriter
+    {
+        protected void AppendGeneralHeaders<T, U>(T playlist, ref StringBuilder sb)
+            where T : HlsPlaylist<U>
+            where U : HlsPlaylistEntry
+        {
+            // HLS requires this line as the first line of playlist
+            sb.AppendLine("#EXTM3U");
+            // VERSION always required
+            sb.AppendLine($"#EXT-X-VERSION:{playlist.Version}");
+
+            CheckNullAndAppend("#EXT-X-ALLOW-CACHE", playlist.AllowCache, sb);
+
+            foreach (var currentComment in playlist.Comments)
+            {
+                sb.AppendLine($"#{currentComment}");
+            }
+        }
+        protected void CheckAndAppend<T>(string tag,
+            T element,
+            StringBuilder sb,
+            Func<T, bool> validator)
+        {
+            if (validator(element) == true)
+            {
+                sb.AppendLine($"{tag}:{element}");
+            }
+        }
+
+        protected void CheckNullAndAppend<T>(string tag,
+            T element,
+            StringBuilder sb)
+        {
+            CheckAndAppend(tag, element, sb, e => e != null);
+        }
+
+        protected void CheckEmptyStringAndAppend(string tag,
+            string element,
+            StringBuilder sb)
+        {
+            CheckAndAppend(tag, element, sb, e => !String.IsNullOrEmpty(e));
+        }
+    }
 }

--- a/PlaylistsNET/Content/IPlaylistParser.cs
+++ b/PlaylistsNET/Content/IPlaylistParser.cs
@@ -7,6 +7,6 @@ namespace PlaylistsNET.Content
     {
         T GetFromStream(Stream stream);
 
-		T GetFromString(string playlistString);
+        T GetFromString(string playlistString);
     }
 }

--- a/PlaylistsNET/Content/M3uContent.cs
+++ b/PlaylistsNET/Content/M3uContent.cs
@@ -9,163 +9,163 @@ using PlaylistsNET.Models;
 
 namespace PlaylistsNET.Content
 {
-	public class M3uContent : IPlaylistParser<M3uPlaylist>, IPlaylistWriter<M3uPlaylist>
-	{
-		public string ToText(M3uPlaylist playlist)
-		{
-			StringBuilder sb = new StringBuilder();
+    public class M3uContent : IPlaylistParser<M3uPlaylist>, IPlaylistWriter<M3uPlaylist>
+    {
+        public string ToText(M3uPlaylist playlist)
+        {
+            StringBuilder sb = new StringBuilder();
 
-			if (playlist.IsExtended)
-			{
-				sb.AppendLine("#EXTM3U");
-			}
+            if (playlist.IsExtended)
+            {
+                sb.AppendLine("#EXTM3U");
+            }
 
-			foreach (var currentComment in playlist.Comments)
-			{
-				sb.AppendLine($"#{currentComment}");
-			}
+            foreach (var currentComment in playlist.Comments)
+            {
+                sb.AppendLine($"#{currentComment}");
+            }
 
-			foreach (var entry in playlist.PlaylistEntries)
-			{
-				if (playlist.IsExtended)
-				{
-					foreach (var currentComment in entry.Comments)
-					{
-						sb.AppendLine($"#{currentComment}");
-					}
-					if (!String.IsNullOrEmpty(entry.Album))
-					{
-						sb.Append("#EXTALB:").Append(entry.Album).AppendLine();
-					}
-					if (!String.IsNullOrEmpty(entry.AlbumArtist))
-					{
-						sb.Append("#EXTART:").Append(entry.AlbumArtist).AppendLine();
-					}
-					if (entry.CustomProperties != null)
-					{
-						foreach (var customProperty in entry.CustomProperties.Where(x => !string.IsNullOrEmpty(x.Value)))
-						{
-							sb.AppendLine($"#{customProperty.Key}:{customProperty.Value}");
-						}
-					}
-					sb.AppendLine($"#EXTINF:{(int)entry.Duration.TotalSeconds},{entry.Title}");
-				}
-				sb.AppendLine(entry.Path);
-			}
+            foreach (var entry in playlist.PlaylistEntries)
+            {
+                if (playlist.IsExtended)
+                {
+                    foreach (var currentComment in entry.Comments)
+                    {
+                        sb.AppendLine($"#{currentComment}");
+                    }
+                    if (!String.IsNullOrEmpty(entry.Album))
+                    {
+                        sb.Append("#EXTALB:").Append(entry.Album).AppendLine();
+                    }
+                    if (!String.IsNullOrEmpty(entry.AlbumArtist))
+                    {
+                        sb.Append("#EXTART:").Append(entry.AlbumArtist).AppendLine();
+                    }
+                    if (entry.CustomProperties != null)
+                    {
+                        foreach (var customProperty in entry.CustomProperties.Where(x => !string.IsNullOrEmpty(x.Value)))
+                        {
+                            sb.AppendLine($"#{customProperty.Key}:{customProperty.Value}");
+                        }
+                    }
+                    sb.AppendLine($"#EXTINF:{(int)entry.Duration.TotalSeconds},{entry.Title}");
+                }
+                sb.AppendLine(entry.Path);
+            }
 
-			return sb.ToString().Trim();
-		}
+            return sb.ToString().Trim();
+        }
 
-		public M3uPlaylist GetFromStream(Stream stream)
-		{
-			StreamReader streamReader = new StreamReader(stream);
-			return GetFromString(streamReader.ReadToEnd());
-		}
+        public M3uPlaylist GetFromStream(Stream stream)
+        {
+            StreamReader streamReader = new StreamReader(stream);
+            return GetFromString(streamReader.ReadToEnd());
+        }
 
-		public M3uPlaylist GetFromString(string playlistString)
-		{
-			var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
+        public M3uPlaylist GetFromString(string playlistString)
+        {
+            var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
 
-			// Not an EXT playlist, so parse with the standard parser
-			if (playlistLines[0] != "#EXTM3U")
-			{
-				return GetM3u(playlistLines);
-			}
+            // Not an EXT playlist, so parse with the standard parser
+            if (playlistLines[0] != "#EXTM3U")
+            {
+                return GetM3u(playlistLines);
+            }
 
-			// Remove "#EXTM3U" as it is no longer needed
-			playlistLines.RemoveAt(0);
+            // Remove "#EXTM3U" as it is no longer needed
+            playlistLines.RemoveAt(0);
 
-			// EXT playlist, but not HLS playlist, parse with the EXT parser
-			var isHls = playlistLines.Any(x => Regex.IsMatch(x, @"^#EXT-X-VERSION:\d$"));
-			if (!isHls)
-			{
-				return GetExtM3u(playlistLines);
-			}
+            // EXT playlist, but not HLS playlist, parse with the EXT parser
+            var isHls = playlistLines.Any(x => Regex.IsMatch(x, @"^#EXT-X-VERSION:\d$"));
+            if (!isHls)
+            {
+                return GetExtM3u(playlistLines);
+            }
 
-			throw new FormatException("Playlist appears to be a HLS playlist. Use the HLS parser instead.");
-		}
+            throw new FormatException("Playlist appears to be a HLS playlist. Use the HLS parser instead.");
+        }
 
-		private M3uPlaylist GetM3u(IEnumerable<string> playlistLines)
-		{
-			var playlist = new M3uPlaylist();
+        private M3uPlaylist GetM3u(IEnumerable<string> playlistLines)
+        {
+            var playlist = new M3uPlaylist();
 
-			foreach (var currentLine in playlistLines)
-			{
-				var Match = Regex.Match(currentLine, @"^#(.*)$");
-				if (Match.Success)
-				{
-					playlist.Comments.Add(currentLine);
-					continue;
-				}
+            foreach (var currentLine in playlistLines)
+            {
+                var Match = Regex.Match(currentLine, @"^#(.*)$");
+                if (Match.Success)
+                {
+                    playlist.Comments.Add(currentLine);
+                    continue;
+                }
 
-				playlist.PlaylistEntries.Add(new M3uPlaylistEntry()
-				{
-					Path = currentLine,
-					Title = "",
-					Album = "",
-					AlbumArtist = "",
-				});
-			}
+                playlist.PlaylistEntries.Add(new M3uPlaylistEntry()
+                {
+                    Path = currentLine,
+                    Title = "",
+                    Album = "",
+                    AlbumArtist = "",
+                });
+            }
 
-			return playlist;
-		}
+            return playlist;
+        }
 
-		private M3uPlaylist GetExtM3u(IEnumerable<string> playlistLines)
-		{
-			var playlist = new M3uPlaylist
-			{
-				IsExtended = true,
-			};
+        private M3uPlaylist GetExtM3u(IEnumerable<string> playlistLines)
+        {
+            var playlist = new M3uPlaylist
+            {
+                IsExtended = true,
+            };
 
-			var currentEntry = new M3uPlaylistEntry {Album = "", AlbumArtist = "", Title = ""};
-			foreach (var currentLine in playlistLines)
-			{
-				var match = Regex.Match(currentLine, @"^#EXTINF:(-?\d*),(.*)$");
-				if (match.Success)
-				{
-					var seconds = string.IsNullOrEmpty(match.Groups[1].Value) ? 0 : double.Parse(match.Groups[1].Value);
-					currentEntry.Duration = TimeSpan.FromSeconds(seconds);
-					currentEntry.Title = match.Groups[2].Value;
-					continue;
-				}
+            var currentEntry = new M3uPlaylistEntry {Album = "", AlbumArtist = "", Title = ""};
+            foreach (var currentLine in playlistLines)
+            {
+                var match = Regex.Match(currentLine, @"^#EXTINF:(-?\d*),(.*)$");
+                if (match.Success)
+                {
+                    var seconds = string.IsNullOrEmpty(match.Groups[1].Value) ? 0 : double.Parse(match.Groups[1].Value);
+                    currentEntry.Duration = TimeSpan.FromSeconds(seconds);
+                    currentEntry.Title = match.Groups[2].Value;
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(EXTALB):(.*)$");
-				if (match.Success)
-				{
-					currentEntry.Album = match.Groups[2].Value;
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(EXTALB):(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.Album = match.Groups[2].Value;
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(EXTART):(.*)$");
-				if (match.Success)
-				{
-					currentEntry.AlbumArtist = match.Groups[2].Value;
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(EXTART):(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.AlbumArtist = match.Groups[2].Value;
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(EXT.*):(.*)$");
-				if (match.Success)
-				{
-					currentEntry.CustomProperties.Add(match.Groups[1].Value, match.Groups[2].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(EXT.*):(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.CustomProperties.Add(match.Groups[1].Value, match.Groups[2].Value);
+                    continue;
+                }
 
-				match = Regex.Match(currentLine, @"^#(?!EXT)(.*)$");
-				if (match.Success)
-				{
-					currentEntry.Comments.Add(match.Groups[1].Value);
-					continue;
-				}
+                match = Regex.Match(currentLine, @"^#(?!EXT)(.*)$");
+                if (match.Success)
+                {
+                    currentEntry.Comments.Add(match.Groups[1].Value);
+                    continue;
+                }
 
-				currentEntry.Path = WebUtility.UrlDecode(currentLine);
-				playlist.PlaylistEntries.Add(currentEntry);
-				currentEntry = new M3uPlaylistEntry();
-				currentEntry.Album = "";
-				currentEntry.AlbumArtist = "";
-				currentEntry.Title = "";
-			}
+                currentEntry.Path = WebUtility.UrlDecode(currentLine);
+                playlist.PlaylistEntries.Add(currentEntry);
+                currentEntry = new M3uPlaylistEntry();
+                currentEntry.Album = "";
+                currentEntry.AlbumArtist = "";
+                currentEntry.Title = "";
+            }
 
-			return playlist;
-		}
-	}
+            return playlist;
+        }
+    }
 }

--- a/PlaylistsNET/Content/PlaylistParserFactory.cs
+++ b/PlaylistsNET/Content/PlaylistParserFactory.cs
@@ -3,21 +3,21 @@ using System;
 
 namespace PlaylistsNET.Content
 {
-	public enum PlaylistType
-	{
-		M3U,
-		M3U8,
-		HLSMaster,
-		HlsMedia,
-		PLS,
-		WPL,
-		ZPL
-	}
+    public enum PlaylistType
+    {
+        M3U,
+        M3U8,
+        HLSMaster,
+        HlsMedia,
+        PLS,
+        WPL,
+        ZPL
+    }
 
     public class PlaylistParserFactory
     {
-		public static IPlaylistParser<IBasePlaylist> GetPlaylistParser(string fileType)
-		{
+        public static IPlaylistParser<IBasePlaylist> GetPlaylistParser(string fileType)
+        {
             fileType = fileType.Trim('.');
             try
             {
@@ -28,9 +28,9 @@ namespace PlaylistsNET.Content
             {
                 throw new ArgumentException($"Unsupported playlist extension: {fileType}");
             }
-		}
+        }
 
-		public static IPlaylistParser<IBasePlaylist> GetPlaylistParser(PlaylistType playlistType)
+        public static IPlaylistParser<IBasePlaylist> GetPlaylistParser(PlaylistType playlistType)
         {
             IPlaylistParser<IBasePlaylist> playlistParser;
 
@@ -38,14 +38,14 @@ namespace PlaylistsNET.Content
             {
                 case PlaylistType.M3U:
                 case PlaylistType.M3U8:
-					playlistParser = new M3uContent();
+                    playlistParser = new M3uContent();
                     break;
-				case PlaylistType.HLSMaster:
-					playlistParser = new HlsMasterContent();
-					break;
-				case PlaylistType.HlsMedia:
-					playlistParser = new HlsMediaContent();
-					break;
+                case PlaylistType.HLSMaster:
+                    playlistParser = new HlsMasterContent();
+                    break;
+                case PlaylistType.HlsMedia:
+                    playlistParser = new HlsMediaContent();
+                    break;
                 case PlaylistType.PLS:
                     playlistParser = new PlsContent();
                     break;
@@ -56,7 +56,7 @@ namespace PlaylistsNET.Content
                     playlistParser = new ZplContent();
                     break;
                 default:
-					throw new ArgumentException($"Unsupported playlist type: {playlistType}");
+                    throw new ArgumentException($"Unsupported playlist type: {playlistType}");
             }
             return playlistParser;
         }

--- a/PlaylistsNET/Content/PlaylistToTextHelper.cs
+++ b/PlaylistsNET/Content/PlaylistToTextHelper.cs
@@ -26,6 +26,14 @@ namespace PlaylistsNET.Content
                     var zplWriter = new ZplContent();
                     text = zplWriter.ToText(zpl);
                     break;
+                case HlsMasterPlaylist hls:
+                    var hlsMasterWriter = new HlsMasterContent();
+                    text = hlsMasterWriter.ToText(hls);
+                    break;
+                case HlsMediaPlaylist hls:
+                    var hlsMediaWriter = new HlsMediaContent();
+                    text = hlsMediaWriter.ToText(hls);
+                    break;
                 default:
                     break;
             }

--- a/PlaylistsNET/Content/PlsContent.cs
+++ b/PlaylistsNET/Content/PlsContent.cs
@@ -36,32 +36,32 @@ namespace PlaylistsNET.Content
             return sb.ToString();
         }
 
-		public PlsPlaylist GetFromStream(Stream stream)
-		{
-			StreamReader streamReader = new StreamReader(stream);
-			return GetFromString(streamReader.ReadToEnd());
-		}
+        public PlsPlaylist GetFromStream(Stream stream)
+        {
+            StreamReader streamReader = new StreamReader(stream);
+            return GetFromString(streamReader.ReadToEnd());
+        }
 
         public PlsPlaylist GetFromString(string playlistString)
         {
             PlsPlaylist playlist = new PlsPlaylist();
             playlist.Version = 2;
 
-			var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
+            var playlistLines = playlistString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
 
-			// If there are no lines to parse, return the empty playlist
-			if (playlistLines.Count == 0)
-			{
-				return playlist;
-			}
+            // If there are no lines to parse, return the empty playlist
+            if (playlistLines.Count == 0)
+            {
+                return playlist;
+            }
 
-			// Verify header is [playlist] and return if not
-			if (playlistLines[0] != "[playlist]")
-			{
-				return playlist;
-			}
+            // Verify header is [playlist] and return if not
+            if (playlistLines[0] != "[playlist]")
+            {
+                return playlist;
+            }
 
-			foreach (var line in playlistLines)
+            foreach (var line in playlistLines)
             {
                 int nr = GetNr(line);
                 if (line.StartsWith("File"))

--- a/PlaylistsNET/Content/WplContent.cs
+++ b/PlaylistsNET/Content/WplContent.cs
@@ -49,17 +49,17 @@ namespace PlaylistsNET.Content
             return sb.ToString();
         }
 
-		public WplPlaylist GetFromStream(Stream stream)
-		{
-			StreamReader streamReader = new StreamReader(stream);
-			return GetFromString(streamReader.ReadToEnd());
-		}
+        public WplPlaylist GetFromStream(Stream stream)
+        {
+            StreamReader streamReader = new StreamReader(stream);
+            return GetFromString(streamReader.ReadToEnd());
+        }
 
-		public WplPlaylist GetFromString(string playlistString)
+        public WplPlaylist GetFromString(string playlistString)
         {
             WplPlaylist playlist = new WplPlaylist();
 
-			XDocument doc = XDocument.Parse(playlistString);
+            XDocument doc = XDocument.Parse(playlistString);
             XElement mainDocument = doc.Element("smil");
             XElement head = mainDocument.Element("head");
             playlist.Author = (string)head.Element("author") ?? "";

--- a/PlaylistsNET/Content/ZplContent.cs
+++ b/PlaylistsNET/Content/ZplContent.cs
@@ -49,13 +49,13 @@ namespace PlaylistsNET.Content
             return sb.ToString();
         }
 
-		public ZplPlaylist GetFromStream(Stream stream)
-		{
-			StreamReader streamReader = new StreamReader(stream);
-			return GetFromString(streamReader.ReadToEnd());
-		}
+        public ZplPlaylist GetFromStream(Stream stream)
+        {
+            StreamReader streamReader = new StreamReader(stream);
+            return GetFromString(streamReader.ReadToEnd());
+        }
 
-		public ZplPlaylist GetFromString(string playlistString)
+        public ZplPlaylist GetFromString(string playlistString)
         {
             ZplPlaylist playlist = new ZplPlaylist();
 

--- a/PlaylistsNET/Models/HlsPlaylist.cs
+++ b/PlaylistsNET/Models/HlsPlaylist.cs
@@ -3,45 +3,45 @@ using System.Collections.Generic;
 
 namespace PlaylistsNET.Models
 {
-	public abstract class HlsPlaylist<T> : BasePlaylist<T> where T : HlsPlaylistEntry
-	{
-		public string Name { get; set; }
-		public List<string> Comments { get; set; }
-		public int Version { get; set; }
-		[Obsolete("The EXT-X-ALLOW-CACHE tag was removed in protocol version 7.")]
-		public string AllowCache { get; set; }
+    public abstract class HlsPlaylist<T> : BasePlaylist<T> where T : HlsPlaylistEntry
+    {
+        public string Name { get; set; }
+        public List<string> Comments { get; set; }
+        public int Version { get; set; }
+        [Obsolete("The EXT-X-ALLOW-CACHE tag was removed in protocol version 7.")]
+        public string AllowCache { get; set; }
 
-		public HlsPlaylist()
-		{
-			Comments = new List<string>();
-		}
-	}
+        public HlsPlaylist()
+        {
+            Comments = new List<string>();
+        }
+    }
 
-	public class HlsMediaPlaylist : HlsPlaylist<HlsMediaPlaylistEntry>
-	{
-		public long MediaSequence { get; set; }
-		public int? TargetDuration { get; set; }
-		public long? DiscontinuitySequence { get; set; }
-		public string PlaylistType { get; set; }
-		public bool EndList { get; set; }
-		public bool IFramesOnly { get; set; }
+    public class HlsMediaPlaylist : HlsPlaylist<HlsMediaPlaylistEntry>
+    {
+        public long MediaSequence { get; set; }
+        public int? TargetDuration { get; set; }
+        public long? DiscontinuitySequence { get; set; }
+        public string PlaylistType { get; set; }
+        public bool EndList { get; set; }
+        public bool IFramesOnly { get; set; }
 
-		public HlsMediaPlaylist() : base() { }
-	}
+        public HlsMediaPlaylist() : base() { }
+    }
 
-	public class HlsMasterPlaylist : HlsPlaylist<HlsMasterPlaylistEntry>
-	{
-		public List<string> Media { get; set; }
-		public List<string> IFrameStreamInf { get; set; }
-		public List<string> SessionData { get; set; }
-		public List<string> SessionKey { get; set; }
+    public class HlsMasterPlaylist : HlsPlaylist<HlsMasterPlaylistEntry>
+    {
+        public List<string> Media { get; set; }
+        public List<string> IFrameStreamInf { get; set; }
+        public List<string> SessionData { get; set; }
+        public List<string> SessionKey { get; set; }
 
-		public HlsMasterPlaylist() : base()
-		{
-			Media = new List<string>();
-			IFrameStreamInf = new List<string>();
-			SessionData = new List<string>();
-			SessionKey = new List<string>();
-		}
-	}
+        public HlsMasterPlaylist() : base()
+        {
+            Media = new List<string>();
+            IFrameStreamInf = new List<string>();
+            SessionData = new List<string>();
+            SessionKey = new List<string>();
+        }
+    }
 }

--- a/PlaylistsNET/Models/HlsPlaylist.cs
+++ b/PlaylistsNET/Models/HlsPlaylist.cs
@@ -41,7 +41,7 @@ namespace PlaylistsNET.Models
 			Media = new List<string>();
 			IFrameStreamInf = new List<string>();
 			SessionData = new List<string>();
-			SessionData = new List<string>();
+			SessionKey = new List<string>();
 		}
 	}
 }

--- a/PlaylistsNET/Models/HlsPlaylistEntry.cs
+++ b/PlaylistsNET/Models/HlsPlaylistEntry.cs
@@ -4,21 +4,21 @@ using System.Text;
 
 namespace PlaylistsNET.Models
 {
-	public abstract class HlsPlaylistEntry : BasePlaylistEntry
-	{
-		public Dictionary<string, string> CustomProperties { get; set; }
-		public List<string> Comments { get; set; }
+    public abstract class HlsPlaylistEntry : BasePlaylistEntry
+    {
+        public Dictionary<string, string> CustomProperties { get; set; }
+        public List<string> Comments { get; set; }
 
-		public HlsPlaylistEntry()
-		{
-			CustomProperties = new Dictionary<string, string>();
-			Comments = new List<string>();
-		}
+        public HlsPlaylistEntry()
+        {
+            CustomProperties = new Dictionary<string, string>();
+            Comments = new List<string>();
+        }
 
         protected abstract void CheckAndAppend<T>(string tag,
-			T element,
-			StringBuilder sb,
-			Func<T, bool> validator);
+            T element,
+            StringBuilder sb,
+            Func<T, bool> validator);
 
         protected void CheckNullAndAppend<T>(string tag,
             T element,
@@ -35,83 +35,83 @@ namespace PlaylistsNET.Models
         }
     }
 
-	public class HlsMediaPlaylistEntry : HlsPlaylistEntry
-	{
-		public int Duration { get; set; }
-		public string Title { get; set; }
-		public long MediaSequence { get; set; }
-		public bool Discontinuity { get; set; }
-		public string ByteRange { get; set; }
-		public string Key { get; set; }
-		public string Map { get; set; }
-		public DateTime? ProgramDateTime { get; set; }
+    public class HlsMediaPlaylistEntry : HlsPlaylistEntry
+    {
+        public int Duration { get; set; }
+        public string Title { get; set; }
+        public long MediaSequence { get; set; }
+        public bool Discontinuity { get; set; }
+        public string ByteRange { get; set; }
+        public string Key { get; set; }
+        public string Map { get; set; }
+        public DateTime? ProgramDateTime { get; set; }
 
-		public HlsMediaPlaylistEntry() : base() { }
+        public HlsMediaPlaylistEntry() : base() { }
 
         protected override void CheckAndAppend<T>(string tag,
-			T element,
-			StringBuilder sb,
-			Func<T, bool> validator)
+            T element,
+            StringBuilder sb,
+            Func<T, bool> validator)
         {
             if (validator(element) == true)
             {
                 sb.AppendLine($"{tag}:{element}");
             }
-		}
+        }
 
-		public override string ToString()
+        public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
 
-			CheckEmptyStringAndAppend("#EXT-X-BYTERANGE", ByteRange, sb);
-			CheckNullAndAppend("#EXT-X-PROGRAM-DATE-TIME", ProgramDateTime?.ToString("o"), sb);
+            CheckEmptyStringAndAppend("#EXT-X-BYTERANGE", ByteRange, sb);
+            CheckNullAndAppend("#EXT-X-PROGRAM-DATE-TIME", ProgramDateTime?.ToString("o"), sb);
 
-			if(Discontinuity)
-			{
-				sb.AppendLine("#EXT-X-DISCONTINUITY");
-			}
+            if(Discontinuity)
+            {
+                sb.AppendLine("#EXT-X-DISCONTINUITY");
+            }
 
-			string durationTitle = String.Join(",",
-				new string[] { Duration == 0 ? "" : Duration.ToString(), Title });
-			CheckAndAppend("#EXTINF", durationTitle, sb, dt => !dt.Equals(","));
+            string durationTitle = String.Join(",",
+                new string[] { Duration == 0 ? "" : Duration.ToString(), Title });
+            CheckAndAppend("#EXTINF", durationTitle, sb, dt => !dt.Equals(","));
 
-			foreach(var kv in CustomProperties)
-			{
-				sb.AppendLine($"#EXT{kv.Key}:{kv.Value}");
-			}
+            foreach(var kv in CustomProperties)
+            {
+                sb.AppendLine($"#EXT{kv.Key}:{kv.Value}");
+            }
 
-			Comments.ForEach(comment => sb.AppendLine($"#{comment}"));
+            Comments.ForEach(comment => sb.AppendLine($"#{comment}"));
 
-			sb.AppendLine(Path.TrimEnd());
+            sb.AppendLine(Path.TrimEnd());
 
-			return sb.ToString();
+            return sb.ToString();
         }
     }
 
-	public class HlsMasterPlaylistEntry : HlsPlaylistEntry
-	{
-		[Obsolete("The PROGRAM-ID attribute of the EXT-X-STREAM-INF tag was removed in protocol version 6.")]
-		public int? ProgramId { get; set; }
-		public int Bandwidth { get; set; }
-		public int? AverageBandwidth { get; set; }
-		public List<string> Codecs { get; set; }
-		public string Resolution { get; set; }
-		public double? FrameRate { get; set; }
-		public string HdcpLevel { get; set; }
-		public string Audio { get; set; }
-		public string Video { get; set; }
-		public string Subtitles { get; set; }
-		public string ClosedCaptions { get; set; }
+    public class HlsMasterPlaylistEntry : HlsPlaylistEntry
+    {
+        [Obsolete("The PROGRAM-ID attribute of the EXT-X-STREAM-INF tag was removed in protocol version 6.")]
+        public int? ProgramId { get; set; }
+        public int Bandwidth { get; set; }
+        public int? AverageBandwidth { get; set; }
+        public List<string> Codecs { get; set; }
+        public string Resolution { get; set; }
+        public double? FrameRate { get; set; }
+        public string HdcpLevel { get; set; }
+        public string Audio { get; set; }
+        public string Video { get; set; }
+        public string Subtitles { get; set; }
+        public string ClosedCaptions { get; set; }
 
-		public HlsMasterPlaylistEntry() : base()
-		{
-			Codecs = new List<string>();
-		}
+        public HlsMasterPlaylistEntry() : base()
+        {
+            Codecs = new List<string>();
+        }
 
         protected override void CheckAndAppend<T>(string tag,
-			T element,
-			StringBuilder sb,
-			Func<T, bool> validator)
+            T element,
+            StringBuilder sb,
+            Func<T, bool> validator)
         {
             if (validator(element) == true)
             {
@@ -120,12 +120,12 @@ namespace PlaylistsNET.Models
         }
 
         public override string ToString()
-		{
-			StringBuilder sb = new StringBuilder();
+        {
+            StringBuilder sb = new StringBuilder();
 
-			sb.Append("#EXT-X-STREAM-INF:");
-			CheckNullAndAppend("PROGRAM-ID", ProgramId, sb);
-			sb.Append($"BANDWIDTH={Bandwidth},");
+            sb.Append("#EXT-X-STREAM-INF:");
+            CheckNullAndAppend("PROGRAM-ID", ProgramId, sb);
+            sb.Append($"BANDWIDTH={Bandwidth},");
             CheckNullAndAppend("AVERAGE-BANDWIDTH", AverageBandwidth, sb);
             CheckEmptyStringAndAppend("CODECS", $"\"{String.Join(",", Codecs)}\"", sb);
             CheckEmptyStringAndAppend("RESOLUTION", Resolution, sb);
@@ -136,16 +136,16 @@ namespace PlaylistsNET.Models
             CheckEmptyStringAndAppend("SUBTITLES", Subtitles, sb);
             CheckEmptyStringAndAppend("CLOSED-CAPTIONS", ClosedCaptions, sb);
 
-			int last = sb.Length - 1;
-			if(sb[last] == ',')
-			{
-				sb.Remove(last, 1);
-			}
+            int last = sb.Length - 1;
+            if(sb[last] == ',')
+            {
+                sb.Remove(last, 1);
+            }
 
-			sb.AppendLine();
-			sb.AppendLine(Path);
+            sb.AppendLine();
+            sb.AppendLine(Path);
 
-			return sb.ToString();
-		}
-	}
+            return sb.ToString();
+        }
+    }
 }

--- a/PlaylistsNET/Models/HlsPlaylistEntry.cs
+++ b/PlaylistsNET/Models/HlsPlaylistEntry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace PlaylistsNET.Models
 {
@@ -13,7 +14,26 @@ namespace PlaylistsNET.Models
 			CustomProperties = new Dictionary<string, string>();
 			Comments = new List<string>();
 		}
-	}
+
+        protected abstract void CheckAndAppend<T>(string tag,
+			T element,
+			StringBuilder sb,
+			Func<T, bool> validator);
+
+        protected void CheckNullAndAppend<T>(string tag,
+            T element,
+            StringBuilder sb)
+        {
+            CheckAndAppend(tag, element, sb, e => e != null);
+        }
+
+        protected void CheckEmptyStringAndAppend(string tag,
+            string element,
+            StringBuilder sb)
+        {
+            CheckAndAppend(tag, element, sb, e => !String.IsNullOrEmpty(e));
+        }
+    }
 
 	public class HlsMediaPlaylistEntry : HlsPlaylistEntry
 	{
@@ -27,7 +47,46 @@ namespace PlaylistsNET.Models
 		public DateTime? ProgramDateTime { get; set; }
 
 		public HlsMediaPlaylistEntry() : base() { }
-	}
+
+        protected override void CheckAndAppend<T>(string tag,
+			T element,
+			StringBuilder sb,
+			Func<T, bool> validator)
+        {
+            if (validator(element) == true)
+            {
+                sb.AppendLine($"{tag}:{element}");
+            }
+		}
+
+		public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+			CheckEmptyStringAndAppend("#EXT-X-BYTERANGE", ByteRange, sb);
+			CheckNullAndAppend("#EXT-X-PROGRAM-DATE-TIME", ProgramDateTime?.ToString("o"), sb);
+
+			if(Discontinuity)
+			{
+				sb.AppendLine("#EXT-X-DISCONTINUITY");
+			}
+
+			string durationTitle = String.Join(",",
+				new string[] { Duration == 0 ? "" : Duration.ToString(), Title });
+			CheckAndAppend("#EXTINF", durationTitle, sb, dt => !dt.Equals(","));
+
+			foreach(var kv in CustomProperties)
+			{
+				sb.AppendLine($"#EXT{kv.Key}:{kv.Value}");
+			}
+
+			Comments.ForEach(comment => sb.AppendLine($"#{comment}"));
+
+			sb.AppendLine(Path.TrimEnd());
+
+			return sb.ToString();
+        }
+    }
 
 	public class HlsMasterPlaylistEntry : HlsPlaylistEntry
 	{
@@ -47,6 +106,46 @@ namespace PlaylistsNET.Models
 		public HlsMasterPlaylistEntry() : base()
 		{
 			Codecs = new List<string>();
+		}
+
+        protected override void CheckAndAppend<T>(string tag,
+			T element,
+			StringBuilder sb,
+			Func<T, bool> validator)
+        {
+            if (validator(element) == true)
+            {
+                sb.Append($"{tag}={element},");
+            }
+        }
+
+        public override string ToString()
+		{
+			StringBuilder sb = new StringBuilder();
+
+			sb.Append("#EXT-X-STREAM-INF:");
+			CheckNullAndAppend("PROGRAM-ID", ProgramId, sb);
+			sb.Append($"BANDWIDTH={Bandwidth},");
+            CheckNullAndAppend("AVERAGE-BANDWIDTH", AverageBandwidth, sb);
+            CheckEmptyStringAndAppend("CODECS", $"\"{String.Join(",", Codecs)}\"", sb);
+            CheckEmptyStringAndAppend("RESOLUTION", Resolution, sb);
+            CheckNullAndAppend("FRAME-RATE", FrameRate, sb);
+            CheckEmptyStringAndAppend("HDCP-LEVEL", HdcpLevel, sb);
+            CheckEmptyStringAndAppend("AUDIO", Audio, sb);
+            CheckEmptyStringAndAppend("VIDEO", Video, sb);
+            CheckEmptyStringAndAppend("SUBTITLES", Subtitles, sb);
+            CheckEmptyStringAndAppend("CLOSED-CAPTIONS", ClosedCaptions, sb);
+
+			int last = sb.Length - 1;
+			if(sb[last] == ',')
+			{
+				sb.Remove(last, 1);
+			}
+
+			sb.AppendLine();
+			sb.AppendLine(Path);
+
+			return sb.ToString();
 		}
 	}
 }

--- a/PlaylistsNET/Models/M3uPlaylist.cs
+++ b/PlaylistsNET/Models/M3uPlaylist.cs
@@ -3,13 +3,13 @@
 namespace PlaylistsNET.Models
 {
     public class M3uPlaylist : BasePlaylist<M3uPlaylistEntry>
-	{
-		public M3uPlaylist()
-		{
-			Comments = new List<string>();
-		}
+    {
+        public M3uPlaylist()
+        {
+            Comments = new List<string>();
+        }
 
-		public bool IsExtended { get; set; }
-		public List<string> Comments { get; set; }
-	}
+        public bool IsExtended { get; set; }
+        public List<string> Comments { get; set; }
+    }
 }


### PR DESCRIPTION
Added support for converting HlsMasterPlaylists and HlsMediaPlaylists to text.

- Added ToText methods for HlsMasterPlaylist and HlsMediaPlaylist
- Integrated with PlaylistToTextHelper
- Added tests for converting test files to Hls(Master|Media)Playlist, ToText, and back to playlists